### PR TITLE
Moving error handling to avoid nil pointer reference

### DIFF
--- a/credhub_exporter.go
+++ b/credhub_exporter.go
@@ -152,6 +152,11 @@ func main() {
 			"",
 			true,
 		)))
+	
+	if err != nil {
+		log.Errorf("Error creating Credhub client: %s", err.Error())
+		os.Exit(1)
+	}
 
 	if len(*caCertPath) != 0 {
 		b, err := ioutil.ReadFile(*caCertPath)
@@ -160,11 +165,6 @@ func main() {
 			os.Exit(1)
 		}
 		credhub.CaCerts(string(b))(credhubCli)
-	}
-
-	if err != nil {
-		log.Errorf("Error creating Credhub client: %s", err.Error())
-		os.Exit(1)
 	}
 
 	regexps := []string{}


### PR DESCRIPTION
If the credhubCli cannot be created because of an error, there is going to be a nil pointer when it is passed into the `credhub.CaCerts` function. This would swallow the original root cause of the error.