### PR TITLE
Added flush-metrics-cache argument to prevent caching of deleted creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ uaac client add prometheus-credhub \
 | `web.auth.username`<br />`CREDHUB_EXPORTER_WEB_AUTH_USERNAME`               | No       |            | Username for web interface basic auth                                                                                                                                                                                                 |
 | `web.auth.password`<br />`CREDHUB_EXPORTER_WEB_AUTH_PASSWORD`               | No       |            | Password for web interface basic auth                                                                                                                                                                                                 |
 | `web.tls.cert_file`<br />`CREDHUB_EXPORTER_WEB_TLS_CERTFILE`                | No       |            | Path to a file that contains the TLS certificate (PEM format). If the certificate is signed by a certificate authority, the file should be the concatenation of the server's certificate, any intermediates, and the CA's certificate |
-| `web.tls.key_file`<br />`CREDHUB_EXPORTER_WEB_TLS_KEYFILE`                  | No       |            | Path to a file that contains the TLS private key (PEM format)                                                                                                                                                                         |
+| `web.tls.key_file`<br />`CREDHUB_EXPORTER_WEB_TLS_KEYFILE`                  | No       |            | Path to a file that contains the TLS private key (PEM format)        
+| `flush-metrics-cache`<br />`CREDHUB_EXPORTER_FLUSH_METRICS_CACHE`           | No       | `false`    | Flushes the collector `credentialMetrics` and `certificateExpiresMetrics` vector to prevent deleted credentials from continuing to report.                                                                                                                                                                
 
 
 ### Metrics

--- a/collector.go
+++ b/collector.go
@@ -29,6 +29,7 @@ type CredhubCollector struct {
 	certificateExpiresMetrics *prometheus.GaugeVec
 	scrapeErrorMetric         prometheus.Gauge
 	lastScrapeTimestampMetric prometheus.Gauge
+	flushCache				  bool
 }
 
 // NewCredhubCollector -
@@ -151,6 +152,12 @@ func (c CredhubCollector) filterCertificates(name string, cred credentials.Crede
 
 func (c CredhubCollector) Collect(ch chan<- prometheus.Metric) {
 	log.Debugf("collecting credhub metrics")
+	if c.flushCache {
+		log.Debugf("flushing credhub metrics cache")
+		c.credentialMetrics.Reset()
+		c.certificateExpiresMetrics.Reset()
+	}
+
 	c.scrapeErrorMetric.Set(0.0)
 	c.lastScrapeTimestampMetric.Set(float64(time.Now().Unix()))
 
@@ -198,6 +205,7 @@ func (c CredhubCollector) Collect(ch chan<- prometheus.Metric) {
 			c.filterCertificates(name, cred)
 		}
 	}
+
 
 	c.credentialMetrics.Collect(ch)
 	c.certificateExpiresMetrics.Collect(ch)

--- a/credhub_exporter.go
+++ b/credhub_exporter.go
@@ -86,6 +86,10 @@ var (
 	tlsKeyFile = kingpin.Flag(
 		"web.tls.key_file", "Path to a file that contains the TLS private key (PEM format) ($CREDHUB_EXPORTER_WEB_TLS_KEYFILE)",
 	).Envar("CREDHUB_EXPORTER_WEB_TLS_KEYFILE").ExistingFile()
+
+	flushCache = kingpin.Flag(
+		"flush-metrics-cache", "Flush metrics cache on each collection ($CREDHUB_EXPORTER_FLUSH_METRICS_CACHE)",
+	).Envar("CREDHUB_EXPORTER_FLUSH_METRICS_CACHE").Default("false").Bool()
 )
 
 func init() {
@@ -186,6 +190,7 @@ func main() {
 	credhubCollector := NewCredhubCollector(*metricsDeployment, *metricsEnvironment, filters, credhubCli)
 	credhubCollector.filterNameLike(*filterNameLike)
 	credhubCollector.filterPath(*filterPath)
+	credhubCollector.flushCache = *flushCache
 	prometheus.MustRegister(credhubCollector)
 
 	handler := prometheusHandler()


### PR DESCRIPTION
Added `flush-metrics-cache` `CREDHUB_EXPORTER_FLUSH_METRICS_CACHE` argument which will clear the `credentialMetrics` and `certificateExpiresMetrics` vectors on each run of the collectors.

Previously, a deleted metric from credhub would continue reporting from credhub-exporter until the process was restarted

Addresses issue #11 